### PR TITLE
Allow Stack Traces to be displayed Client side

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
 		<artifactId>oss-parent</artifactId>
 		<groupId>org.sonatype.oss</groupId>
@@ -48,10 +48,10 @@
 	</licenses>
 
 	<properties>
-		<gwt.version>2.0.4</gwt.version>
+		<gwt.version>2.7.0</gwt.version>
 		<guice.version>2.0</guice.version>
 		<gin.version>1.0</gin.version>
-		<appengine.version>1.2.1</appengine.version>
+		<appengine.version>1.9.28</appengine.version>
 		<spring.version>2.5.6</spring.version>
 		<gwt.extraJvmArgs>-Xmx512m</gwt.extraJvmArgs>
 	</properties>
@@ -166,16 +166,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0</version>
+				<version>3.3</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.2</version>
+				<version>2.4</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -213,7 +213,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>gwt-maven-plugin</artifactId>
-				<version>1.2</version>
+				<version>2.7.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/src/main/java/net/customware/gwt/dispatch/shared/DispatchException.java
+++ b/src/main/java/net/customware/gwt/dispatch/shared/DispatchException.java
@@ -1,5 +1,6 @@
 package net.customware.gwt.dispatch.shared;
 
+import com.google.gwt.core.shared.SerializableThrowable;
 import java.io.Serializable;
 
 /**
@@ -27,6 +28,11 @@ public abstract class DispatchException extends Exception implements Serializabl
     public DispatchException( String message, Throwable cause ) {
         super( message + " (" + cause.getMessage() + ")" );
         this.causeClassname = cause.getClass().getName();
+    }
+
+    public DispatchException( SerializableThrowable serializableThrowable ) {
+        super(serializableThrowable);
+        causeClassname = serializableThrowable.getClass().getName();
     }
 
     public String getCauseClassname() {

--- a/src/main/java/net/customware/gwt/dispatch/shared/SerializableDispatchException.java
+++ b/src/main/java/net/customware/gwt/dispatch/shared/SerializableDispatchException.java
@@ -1,0 +1,44 @@
+package net.customware.gwt.dispatch.shared;
+
+import com.google.gwt.core.shared.SerializableThrowable;
+import java.io.PrintStream;
+
+/**
+ * Thin Wrapper Around {@link SerializableThrowable}, used to allow full stacktraces to be displayed client side
+ *
+ * @author Ciaran Liedeman
+ */
+public class SerializableDispatchException extends DispatchException {
+
+    private SerializableThrowable serializableThrowable;
+
+    public SerializableDispatchException() {
+    }
+
+    public SerializableDispatchException( SerializableThrowable serializableThrowable ) {
+        this.serializableThrowable = serializableThrowable;
+    }
+
+    @Override
+    public void printStackTrace() {
+        serializableThrowable.printStackTrace();
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        serializableThrowable.printStackTrace(s);
+    }
+
+    public SerializableThrowable getSerializableThrowable() {
+        return serializableThrowable;
+    }
+
+    public void setSerializableThrowable( SerializableThrowable serializableThrowable ) {
+        this.serializableThrowable = serializableThrowable;
+    }
+
+    @Override
+    public StackTraceElement[] getStackTrace() {
+        return serializableThrowable.getStackTrace();
+    }
+}

--- a/src/test/java/net/customware/gwt/dispatch/client/standard/GwtTestStandardDispatcher.java
+++ b/src/test/java/net/customware/gwt/dispatch/client/standard/GwtTestStandardDispatcher.java
@@ -41,15 +41,21 @@ public class GwtTestStandardDispatcher extends AbstractGwtTestCase {
 
         super.gwtTearDown();
     }
-    
+
     public void testIncrementCounter() {
-        
-        dispatch.execute( new IncrementCounter( 1 ), new TestCallback<IncrementCounterResult>() {
-            public void onSuccess( IncrementCounterResult result ) {
-                assertEquals( 1, result.getCurrent() );
-                finishTest();
+
+        dispatch.execute( new ResetCounter(), new TestCallback<ResetCounterResult>() {
+
+            @Override
+            public void onSuccess( ResetCounterResult result ) {
+                dispatch.execute( new IncrementCounter( 1 ), new TestCallback<IncrementCounterResult>() {
+                    public void onSuccess( IncrementCounterResult innerResult ) {
+                        assertEquals( 1, innerResult.getCurrent() );
+                        finishTest();
+                    }
+                } );
             }
-        } );
+        });
         
         // Set a delay period significantly longer than the
         // event is expected to take.


### PR DESCRIPTION
Hi, I am creating this pull request to allow stack traces to be displayed client side using a [gwt 2.6 enhancement ](http://www.gwtproject.org/javadoc/latest/com/google/gwt/core/shared/SerializableThrowable.html). Unforuntately something seems to have changed in the GwtTestCase implementation because now the Standard Servlet Test fails. This failure seems to be caused by the tests not running in the order they are written. I wanted to know if you have any ideas on how I should fix this? I could split the test out but that seems like a poor and confusing solution.
